### PR TITLE
404page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+// filepath: d:\Coding\earthmc-web-data\index.html
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -5,6 +6,40 @@
     <link rel="icon" type="image/svg+xml" href="/logo.avif" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>EarthMC Web Data</title>
+
+    <script type="text/javascript">
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script checks to see if a redirect is present in the query string
+      // and converts it back into the correct url and adds it to the
+      // browser's history using window.history.replaceState(...),
+      // which won't cause the browser to attempt to load the new url.
+      // When the single page app is loaded further down in this file,
+      // the correct url will be waiting in the browser's history for
+      // the single page app to route accordingly.
+      (function (l) {
+        if (l.search) {
+          var q = {};
+          l.search
+            .slice(1)
+            .split("&")
+            .forEach(function (v) {
+              var a = v.split("=");
+              q[a[0]] = a.slice(1).join("=").replace(/~and~/g, "&");
+            });
+          if (q.p !== undefined) {
+            window.history.replaceState(
+              null,
+              null,
+              l.pathname.slice(0, -1) +
+                (q.p.startsWith("/") ? q.p : "/" + q.p) + // Ensure q.p starts with a slash
+                (q.q ? "?" + q.q : "") +
+                l.hash
+            );
+          }
+        }
+      })(window.location);
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-// filepath: d:\Coding\earthmc-web-data\index.html
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Single Page Apps for GitHub Pages</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe becomes
+      // https://www.foo.tld/?p=/one/two&q=a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for Internet Explorer to display it.
+      var l = window.location;
+      var segmentCount = 1; // IMPORTANT: Set to 1 for <username>.github.io/<reponame>/
+
+      l.replace(
+        l.protocol +
+          "//" +
+          l.hostname +
+          (l.port ? ":" + l.port : "") +
+          l.pathname
+            .split("/")
+            .slice(0, 1 + segmentCount)
+            .join("/") +
+          "/?p=/" +
+          l.pathname
+            .slice(1)
+            .split("/")
+            .slice(segmentCount)
+            .join("/")
+            .replace(/&/g, "~and~") +
+          (l.search ? "&q=" + l.search.slice(1).replace(/&/g, "~and~") : "") +
+          l.hash
+      );
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Single Page Apps for GitHub Pages</title>
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages


### PR DESCRIPTION
This pull request introduces changes to support Single Page Application (SPA) routing for GitHub Pages. The changes include adding JavaScript scripts to handle URL redirection and routing for SPAs, ensuring compatibility with GitHub Pages' static hosting.

### SPA Routing Support:

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R8-R41): Added a script to handle query string-based redirects. This ensures that when a user navigates to a specific route, the correct URL is reconstructed and added to the browser's history for proper SPA routing.
* [`public/404.html`](diffhunk://#diff-f934e43e0f8ddbcd51317189e847c41f190ec983462fc3bd7169b8d7f1a99cf6R1-R42): Created a custom `404.html` file with a script to convert the path and query string into a query string format and redirect the browser. This ensures that non-root URLs are routed correctly in GitHub Pages environments.