### PR TITLE
Add towns list & search with view on map

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+// filepath: d:\Coding\earthmc-web-data\index.html
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -5,6 +6,40 @@
     <link rel="icon" type="image/svg+xml" href="/logo.avif" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>EarthMC Web Data</title>
+
+    <script type="text/javascript">
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script checks to see if a redirect is present in the query string
+      // and converts it back into the correct url and adds it to the
+      // browser's history using window.history.replaceState(...),
+      // which won't cause the browser to attempt to load the new url.
+      // When the single page app is loaded further down in this file,
+      // the correct url will be waiting in the browser's history for
+      // the single page app to route accordingly.
+      (function (l) {
+        if (l.search) {
+          var q = {};
+          l.search
+            .slice(1)
+            .split("&")
+            .forEach(function (v) {
+              var a = v.split("=");
+              q[a[0]] = a.slice(1).join("=").replace(/~and~/g, "&");
+            });
+          if (q.p !== undefined) {
+            window.history.replaceState(
+              null,
+              null,
+              l.pathname.slice(0, -1) +
+                (q.p.startsWith("/") ? q.p : "/" + q.p) + // Ensure q.p starts with a slash
+                (q.q ? "?" + q.q : "") +
+                l.hash
+            );
+          }
+        }
+      })(window.location);
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-// filepath: d:\Coding\earthmc-web-data\index.html
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Single Page Apps for GitHub Pages</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe becomes
+      // https://www.foo.tld/?p=/one/two&q=a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for Internet Explorer to display it.
+      var l = window.location;
+      var segmentCount = 1; // IMPORTANT: Set to 1 for <username>.github.io/<reponame>/
+
+      l.replace(
+        l.protocol +
+          "//" +
+          l.hostname +
+          (l.port ? ":" + l.port : "") +
+          l.pathname
+            .split("/")
+            .slice(0, 1 + segmentCount)
+            .join("/") +
+          "/?p=/" +
+          l.pathname
+            .slice(1)
+            .split("/")
+            .slice(segmentCount)
+            .join("/")
+            .replace(/&/g, "~and~") +
+          (l.search ? "&q=" + l.search.slice(1).replace(/&/g, "~and~") : "") +
+          l.hash
+      );
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Single Page Apps for GitHub Pages</title>
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages

--- a/src/components/navbar/NavBar.css
+++ b/src/components/navbar/NavBar.css
@@ -14,6 +14,11 @@ nav h1 {
     font-size: 1.5rem;
 }
 
+nav h1 a {
+    color: white;
+    text-decoration: none;
+}
+
 nav ul {
     list-style-type: none;
     margin: 0;

--- a/src/components/navbar/NavBar.tsx
+++ b/src/components/navbar/NavBar.tsx
@@ -15,14 +15,14 @@ const NavBar = () => {
 
     return (
         <nav>
-            <h1>EarthMC Web Data</h1>
+            <h1><Link to="/">EarthMC Web Data</Link></h1>
             <div className="menu-toggle" onClick={toggleMenu}>
                 <div></div>
                 <div></div>
                 <div></div>
             </div>
             <ul className={menuOpen ? 'open' : ''}>
-                <li><Link to="/" onClick={closeMenu}>Home</Link></li>
+                <li><Link to="/" onClick={closeMenu}>Status</Link></li>
                 <li><Link to="/players" onClick={closeMenu}>Players</Link></li>
                 <li><Link to="/towns" onClick={closeMenu}>Towns</Link></li>
                 <li><Link to="/nations" onClick={closeMenu}>Nations</Link></li>

--- a/src/components/player/Players.tsx
+++ b/src/components/player/Players.tsx
@@ -3,9 +3,8 @@ import type { FormEvent } from 'react';
 import './../Components.css'
 import axios from 'axios';
 import type { PlayerDetailed, PlayerBasic } from '../../interfaces/player';
-import PlayerModal from './PlayerModal'; // Import the modal
+import PlayerModal from './PlayerModal';
 
-// Determine the API base URL based on the environment
 const API_BASE_URL = import.meta.env.DEV ? '/api' : 'https://api.earthmc.net';
 
 const Players = () => {

--- a/src/components/towns/TownModal.tsx
+++ b/src/components/towns/TownModal.tsx
@@ -39,7 +39,7 @@ const TownModal: React.FC<TownModalProps> = ({ town, isOpen, onClose }) => {
     return (
         <div className="modal-overlay" onClick={onClose}>
             <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-                <button className="modal-close-button button" onClick={onClose}>X</button>
+                <button className="modal-close-button button" onClick={onClose} aria-label="Close modal">X</button>
                 <h2>{town.name}</h2>
                 <a href={mapLink} target="_blank" rel="noopener noreferrer">
                     View on Map

--- a/src/components/towns/TownModal.tsx
+++ b/src/components/towns/TownModal.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import type { TownDetailed, TownResident } from '../../interfaces/town';
+import './../Components.css'; // Assuming general modal styles are here
+
+interface TownModalProps {
+    town: TownDetailed | null;
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+const formatDate = (timestamp: number | null): string => {
+    if (timestamp === null) return 'N/A';
+    return new Date(timestamp).toLocaleString();
+};
+
+const formatBoolean = (value: boolean): string => (value ? 'Yes' : 'No');
+
+const TownModal: React.FC<TownModalProps> = ({ town, isOpen, onClose }) => {
+    if (!isOpen || !town) {
+        return null;
+    }
+
+    const renderResidentList = (title: string, residents: TownResident[]) => {
+        if (residents.length === 0) return null;
+        return (
+            <>
+                <h3>{title} ({residents.length}):</h3>
+                <ul>
+                    {residents.map(resident => (
+                        <li key={resident.uuid}>{resident.name} ({resident.uuid})</li>
+                    ))}
+                </ul>
+            </>
+        );
+    };
+
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <button className="modal-close-button button" onClick={onClose}>X</button>
+                <h2>{town.name}</h2>
+                <p><strong>UUID:</strong> {town.uuid}</p>
+                {town.board && <p><strong>Board:</strong> {town.board}</p>}
+                <p><strong>Founder:</strong> {town.founder}</p>
+                {town.wiki && <p><strong>Wiki:</strong> <a href={town.wiki} target="_blank" rel="noopener noreferrer">{town.wiki}</a></p>}
+
+                <h3>Mayor</h3>
+                <p>{town.mayor.name} ({town.mayor.uuid})</p>
+
+                <h3>Nation</h3>
+                <p>{town.nation.name || 'N/A'} {town.nation.uuid && `(${town.nation.uuid})`}</p>
+
+                <h3>Timestamps</h3>
+                <p><strong>Registered:</strong> {formatDate(town.timestamps.registered)}</p>
+                <p><strong>Joined Nation:</strong> {formatDate(town.timestamps.joinedNationAt)}</p>
+                <p><strong>Ruined At:</strong> {formatDate(town.timestamps.ruinedAt)}</p>
+
+                <h3>Status</h3>
+                <p><strong>Public:</strong> {formatBoolean(town.status.isPublic)}</p>
+                <p><strong>Open:</strong> {formatBoolean(town.status.isOpen)}</p>
+                <p><strong>Neutral:</strong> {formatBoolean(town.status.isNeutral)}</p>
+                <p><strong>Capital:</strong> {formatBoolean(town.status.isCapital)}</p>
+                <p><strong>OverClaimed:</strong> {formatBoolean(town.status.isOverClaimed)}</p>
+                <p><strong>Ruined:</strong> {formatBoolean(town.status.isRuined)}</p>
+                <p><strong>For Sale:</strong> {formatBoolean(town.status.isForSale)}</p>
+                <p><strong>Has Nation:</strong> {formatBoolean(town.status.hasNation)}</p>
+                <p><strong>Has Overclaim Shield:</strong> {formatBoolean(town.status.hasOverclaimShield)}</p>
+                <p><strong>Outsiders Can Spawn:</strong> {formatBoolean(town.status.canOutsidersSpawn)}</p>
+
+                <h3>Stats</h3>
+                <p><strong>Town Blocks:</strong> {town.stats.numTownBlocks}</p>
+                <p><strong>Max Town Blocks:</strong> {town.stats.maxTownBlocks}</p>
+                <p><strong>Residents:</strong> {town.stats.numResidents}</p>
+                <p><strong>Trusted:</strong> {town.stats.numTrusted}</p>
+                <p><strong>Outlaws:</strong> {town.stats.numOutlaws}</p>
+                <p><strong>Balance:</strong> {town.stats.balance} gold</p>
+                <p><strong>For Sale Price:</strong> {town.stats.forSalePrice !== null ? `${town.stats.forSalePrice} gold` : 'N/A'}</p>
+
+                <h3>Coordinates</h3>
+                <p><strong>Spawn:</strong> World: {town.coordinates.spawn.world}, X: {town.coordinates.spawn.x.toFixed(2)}, Y: {town.coordinates.spawn.y.toFixed(2)}, Z: {town.coordinates.spawn.z.toFixed(2)}</p>
+                <p><strong>Home Block:</strong> X: {town.coordinates.homeBlock[0]}, Z: {town.coordinates.homeBlock[1]}</p>
+                <p><strong>Town Blocks Count:</strong> {town.coordinates.townBlocks.length}</p>
+                {/* Consider how to display townBlocks if needed, could be a long list */}
+
+                {renderResidentList("Residents", town.residents)}
+                {renderResidentList("Trusted", town.trusted)}
+                {renderResidentList("Outlaws", town.outlaws)}
+
+                {town.quarters.length > 0 && (
+                    <>
+                        <h3>Quarters ({town.quarters.length}):</h3>
+                        <ul>
+                            {town.quarters.map(quarterUuid => (
+                                <li key={quarterUuid}>{quarterUuid}</li>
+                            ))}
+                        </ul>
+                    </>
+                )}
+
+                {Object.keys(town.ranks).length > 0 && (
+                    <>
+                        <h3>Ranks:</h3>
+                        {Object.entries(town.ranks).map(([rankName, players]) => (
+                            players.length > 0 && (
+                                <div key={rankName}>
+                                    <p><strong>{rankName}:</strong> {players.join(', ')}</p>
+                                </div>
+                            )
+                        ))}
+                    </>
+                )}
+
+                <h3>Permissions:</h3>
+                <pre>{JSON.stringify(town.perms, null, 2)}</pre>
+            </div>
+        </div>
+    );
+};
+
+export default TownModal;

--- a/src/components/towns/TownModal.tsx
+++ b/src/components/towns/TownModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import type { TownDetailed, TownResident } from '../../interfaces/town';
-import './../Components.css'; // Assuming general modal styles are here
+import type { TownDetailed, TownResident, TownQuarter, TownRank } from '../../interfaces/town';
+import './../Components.css';
 
 interface TownModalProps {
     town: TownDetailed | null;
@@ -20,13 +20,13 @@ const TownModal: React.FC<TownModalProps> = ({ town, isOpen, onClose }) => {
         return null;
     }
 
-    const renderResidentList = (title: string, residents: TownResident[]) => {
-        if (residents.length === 0) return null;
+    const renderResidentList = (title: string, residents: TownResident[] | undefined) => {
+        if (!residents || residents.length === 0) return null;
         return (
             <>
                 <h3>{title} ({residents.length}):</h3>
                 <ul>
-                    {residents.map(resident => (
+                    {residents.map((resident) => (
                         <li key={resident.uuid}>{resident.name} ({resident.uuid})</li>
                     ))}
                 </ul>
@@ -34,11 +34,16 @@ const TownModal: React.FC<TownModalProps> = ({ town, isOpen, onClose }) => {
         );
     };
 
+    const mapLink = `https://map.earthmc.net/?world=minecraft:overworld&zoom=5&x=${town.coordinates.spawn.x.toFixed(0)}&y=${town.coordinates.spawn.y.toFixed(0)}&z=${town.coordinates.spawn.z.toFixed(0)}`;
+
     return (
         <div className="modal-overlay" onClick={onClose}>
             <div className="modal-content" onClick={(e) => e.stopPropagation()}>
                 <button className="modal-close-button button" onClick={onClose}>X</button>
                 <h2>{town.name}</h2>
+                <a href={mapLink} target="_blank" rel="noopener noreferrer">
+                    View on Map
+                </a>
                 <p><strong>UUID:</strong> {town.uuid}</p>
                 {town.board && <p><strong>Board:</strong> {town.board}</p>}
                 <p><strong>Founder:</strong> {town.founder}</p>
@@ -70,6 +75,7 @@ const TownModal: React.FC<TownModalProps> = ({ town, isOpen, onClose }) => {
                 <h3>Stats</h3>
                 <p><strong>Town Blocks:</strong> {town.stats.numTownBlocks}</p>
                 <p><strong>Max Town Blocks:</strong> {town.stats.maxTownBlocks}</p>
+                <p><strong>Bonus Blocks:</strong> {town.stats.bonusBlocks}</p>
                 <p><strong>Residents:</strong> {town.stats.numResidents}</p>
                 <p><strong>Trusted:</strong> {town.stats.numTrusted}</p>
                 <p><strong>Outlaws:</strong> {town.stats.numOutlaws}</p>
@@ -80,30 +86,34 @@ const TownModal: React.FC<TownModalProps> = ({ town, isOpen, onClose }) => {
                 <p><strong>Spawn:</strong> World: {town.coordinates.spawn.world}, X: {town.coordinates.spawn.x.toFixed(2)}, Y: {town.coordinates.spawn.y.toFixed(2)}, Z: {town.coordinates.spawn.z.toFixed(2)}</p>
                 <p><strong>Home Block:</strong> X: {town.coordinates.homeBlock[0]}, Z: {town.coordinates.homeBlock[1]}</p>
                 <p><strong>Town Blocks Count:</strong> {town.coordinates.townBlocks.length}</p>
-                {/* Consider how to display townBlocks if needed, could be a long list */}
 
                 {renderResidentList("Residents", town.residents)}
                 {renderResidentList("Trusted", town.trusted)}
                 {renderResidentList("Outlaws", town.outlaws)}
 
-                {town.quarters.length > 0 && (
+                {town.quarters && town.quarters.length > 0 && (
                     <>
                         <h3>Quarters ({town.quarters.length}):</h3>
                         <ul>
-                            {town.quarters.map(quarterUuid => (
-                                <li key={quarterUuid}>{quarterUuid}</li>
+                            {town.quarters.map((quarter: TownQuarter) => (
+                                <li key={quarter.uuid}>{quarter.name} ({quarter.uuid})</li>
                             ))}
                         </ul>
                     </>
                 )}
 
-                {Object.keys(town.ranks).length > 0 && (
+                {town.ranks && Object.keys(town.ranks).length > 0 && (
                     <>
                         <h3>Ranks:</h3>
                         {Object.entries(town.ranks).map(([rankName, players]) => (
                             players.length > 0 && (
                                 <div key={rankName}>
-                                    <p><strong>{rankName}:</strong> {players.join(', ')}</p>
+                                    <p><strong>{rankName}:</strong></p>
+                                    <ul>
+                                        {players.map((player: TownRank) => (
+                                            <li key={player.uuid}>{player.name} ({player.uuid})</li>
+                                        ))}
+                                    </ul>
                                 </div>
                             )
                         ))}
@@ -111,7 +121,7 @@ const TownModal: React.FC<TownModalProps> = ({ town, isOpen, onClose }) => {
                 )}
 
                 <h3>Permissions:</h3>
-                <pre>{JSON.stringify(town.perms, null, 2)}</pre>
+                <pre>{JSON.stringify(town.perms || {}, null, 2)}</pre>
             </div>
         </div>
     );

--- a/src/components/towns/Towns.tsx
+++ b/src/components/towns/Towns.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import axios from 'axios';
-import type { TownBasic, TownDetailed } from '../../interfaces/town'
+import type { TownBasic, TownDetailed } from '../../interfaces/town';
 import TownModal from './TownModal';
 import './../Components.css';
 
@@ -61,6 +61,8 @@ const Towns = () => {
                 query: [searchQuery.trim()]
             });
 
+            console.log('API Response:', response.data);
+
             if (response.data) {
                 setSearchedTownData(response.data);
                 if (response.data.length === 1) {
@@ -70,7 +72,6 @@ const Towns = () => {
                 setSearchedTownData([]);
             }
         } catch (err) {
-
             setSearchedTownData(null);
             setErrorSearch(err instanceof Error ? err : new Error(String(err ?? 'Search failed')));
         } finally {
@@ -142,24 +143,20 @@ const Towns = () => {
                         </button>
                     </div>
 
-                    {showRawSearchedData ? (
-                        <pre>{JSON.stringify(searchedTownData, null, 2)}</pre>
+                    {Array.isArray(searchedTownData) && searchedTownData.length > 0 ? (
+                        searchedTownData.map((town) => (
+                            <div key={town.uuid || `fallback-${town.name}`} className="player-search-item">
+                                <h3>{town.name}</h3>
+                                <p><strong>UUID:</strong> {town.uuid}</p>
+                                <p><strong>Mayor:</strong> {town.mayor.name}</p>
+                                <p><strong>Nation:</strong> {town.nation.name || 'N/A'}</p>
+                                <button onClick={() => setModalTown(town)} className="button player-search-details-button">
+                                    View Full Details
+                                </button>
+                            </div>
+                        ))
                     ) : (
-                        searchedTownData.length > 0 ? (
-                            searchedTownData.map(town => (
-                                <div key={town.uuid} className="player-search-item"> {/* Reusing player-search-item style */}
-                                    <h3>{town.name}</h3>
-                                    <p><strong>UUID:</strong> {town.uuid}</p>
-                                    <p><strong>Mayor:</strong> {town.mayor.name}</p>
-                                    <p><strong>Nation:</strong> {town.nation.name || 'N/A'}</p>
-                                    <button onClick={() => setModalTown(town)} className="button player-search-details-button">
-                                        View Full Details
-                                    </button>
-                                </div>
-                            ))
-                        ) : (
-                            <p>No town found for "{searchQuery}".</p>
-                        )
+                        <p>No town found for "{searchQuery}".</p>
                     )}
                 </div>
             )}

--- a/src/components/towns/Towns.tsx
+++ b/src/components/towns/Towns.tsx
@@ -25,7 +25,7 @@ const Towns = () => {
     const [loadingModalTown, setLoadingModalTown] = useState(false);
     const [errorModalTown, setErrorModalTown] = useState<Error | null>(null);
 
-    const toggleRawSearchedData = () => {
+    const toggleRawSearchedData: () => void = () => {
         setShowRawSearchedData(prev => !prev);
     };
 
@@ -60,8 +60,6 @@ const Towns = () => {
             const response = await axios.post<TownDetailed[]>(`${API_BASE_URL}/v3/aurora/towns`, {
                 query: [searchQuery.trim()]
             });
-
-            console.log('API Response:', response.data);
 
             if (response.data) {
                 setSearchedTownData(response.data);

--- a/src/components/towns/Towns.tsx
+++ b/src/components/towns/Towns.tsx
@@ -1,9 +1,214 @@
-const Towns = () => {
-    return (
-        <div className="towns">
-            <h1>Welcome to the Towns Page</h1>
-        </div>
-    )
-}
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import axios from 'axios';
+import type { TownBasic, TownDetailed } from '../../interfaces/town'
+import TownModal from './TownModal';
+import './../Components.css';
 
-export default Towns
+const API_BASE_URL = import.meta.env.DEV ? '/api' : 'https://api.earthmc.net';
+const TOWNS_PER_PAGE = 10;
+
+const Towns = () => {
+    const [searchQuery, setSearchQuery] = useState('');
+    const [searchedTownData, setSearchedTownData] = useState<TownDetailed[] | null>(null);
+    const [loadingSearch, setLoadingSearch] = useState(false);
+    const [errorSearch, setErrorSearch] = useState<Error | null>(null);
+    const [showRawSearchedData, setShowRawSearchedData] = useState(false);
+
+    const [allTowns, setAllTowns] = useState<TownBasic[]>([]);
+    const [loadingAllTowns, setLoadingAllTowns] = useState(true);
+    const [errorAllTowns, setErrorAllTowns] = useState<Error | null>(null);
+
+    const [currentPage, setCurrentPage] = useState(1);
+
+    const [modalTown, setModalTown] = useState<TownDetailed | null>(null);
+    const [loadingModalTown, setLoadingModalTown] = useState(false);
+    const [errorModalTown, setErrorModalTown] = useState<Error | null>(null);
+
+    const toggleRawSearchedData = () => {
+        setShowRawSearchedData(prev => !prev);
+    };
+
+    useEffect(() => {
+        const fetchAllTowns = async () => {
+            setLoadingAllTowns(true);
+            setErrorAllTowns(null);
+            try {
+                const response = await axios.get<TownBasic[]>(`${API_BASE_URL}/v3/aurora/towns`);
+                setAllTowns(response.data);
+            } catch (err) {
+                setErrorAllTowns(err instanceof Error ? err : new Error(String(err ?? 'Failed to fetch towns')));
+            } finally {
+                setLoadingAllTowns(false);
+            }
+        };
+        fetchAllTowns();
+    }, []);
+
+    const handleSearch = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (!searchQuery.trim()) {
+            setSearchedTownData(null);
+            setErrorSearch(null);
+            return;
+        }
+        setLoadingSearch(true);
+        setErrorSearch(null);
+        setSearchedTownData(null);
+
+        try {
+            const response = await axios.post<TownDetailed[]>(`${API_BASE_URL}/v3/aurora/towns`, {
+                query: [searchQuery.trim()]
+            });
+
+            if (response.data) {
+                setSearchedTownData(response.data);
+                if (response.data.length === 1) {
+                    setModalTown(response.data[0]);
+                }
+            } else {
+                setSearchedTownData([]);
+            }
+        } catch (err) {
+
+            setSearchedTownData(null);
+            setErrorSearch(err instanceof Error ? err : new Error(String(err ?? 'Search failed')));
+        } finally {
+            setLoadingSearch(false);
+        }
+    };
+
+    const openTownModalWithDetails = async (townIdentifier: string) => {
+        setLoadingModalTown(true);
+        setErrorModalTown(null);
+        setModalTown(null);
+        try {
+            const response = await axios.post<TownDetailed[]>(`${API_BASE_URL}/v3/aurora/towns`, {
+                query: [townIdentifier]
+            });
+            if (response.data && response.data.length > 0) {
+                setModalTown(response.data[0]);
+            } else {
+                setErrorModalTown(new Error(`Could not fetch details for town: ${townIdentifier}`));
+            }
+        } catch (err) {
+            setErrorModalTown(err instanceof Error ? err : new Error(String(err ?? `Unknown error fetching details for ${townIdentifier}`)));
+        } finally {
+            setLoadingModalTown(false);
+        }
+    };
+
+    const closeModal = () => {
+        setModalTown(null);
+        setErrorModalTown(null);
+    };
+
+    const indexOfLastTown = currentPage * TOWNS_PER_PAGE;
+    const indexOfFirstTown = indexOfLastTown - TOWNS_PER_PAGE;
+    const currentDisplayedTowns = allTowns.slice(indexOfFirstTown, indexOfLastTown);
+    const totalPages = Math.ceil(allTowns.length / TOWNS_PER_PAGE);
+
+    const nextPage = () => setCurrentPage(prev => Math.min(prev + 1, totalPages));
+    const prevPage = () => setCurrentPage(prev => Math.max(prev - 1, 1));
+
+    return (
+        <div className="data-container">
+            <h1>Towns</h1>
+            <form onSubmit={handleSearch} className="player-search-form"> {/* Reusing player-search-form style */}
+                <input
+                    type="text"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    placeholder="Enter town name or UUID"
+                    className="player-search-input" // Reusing player-search-input style
+                />
+                <button type="submit" className="button" disabled={loadingSearch}>
+                    {loadingSearch ? 'Searching...' : 'Search Town'}
+                </button>
+            </form>
+
+            {loadingSearch && <p>Searching for town...</p>}
+            {errorSearch && !loadingSearch && <p>Search Error: {errorSearch.message}</p>}
+
+            {searchedTownData && !loadingSearch && (
+                <div className="data-display search-results-container">
+                    <h2>Search Result:</h2>
+                    <div className='button-container search-results-button-container'>
+                        <button onClick={toggleRawSearchedData} className='button'>
+                            {showRawSearchedData ? 'Hide Raw Data' : 'Show Raw Data'}
+                        </button>
+                        <button onClick={() => { setSearchedTownData(null); setErrorSearch(null); setSearchQuery(''); }} className='button'>
+                            Clear Search & Show All Towns
+                        </button>
+                    </div>
+
+                    {showRawSearchedData ? (
+                        <pre>{JSON.stringify(searchedTownData, null, 2)}</pre>
+                    ) : (
+                        searchedTownData.length > 0 ? (
+                            searchedTownData.map(town => (
+                                <div key={town.uuid} className="player-search-item"> {/* Reusing player-search-item style */}
+                                    <h3>{town.name}</h3>
+                                    <p><strong>UUID:</strong> {town.uuid}</p>
+                                    <p><strong>Mayor:</strong> {town.mayor.name}</p>
+                                    <p><strong>Nation:</strong> {town.nation.name || 'N/A'}</p>
+                                    <button onClick={() => setModalTown(town)} className="button player-search-details-button">
+                                        View Full Details
+                                    </button>
+                                </div>
+                            ))
+                        ) : (
+                            <p>No town found for "{searchQuery}".</p>
+                        )
+                    )}
+                </div>
+            )}
+
+            {!searchedTownData && !errorSearch && (
+                <div className="all-players-list-container"> {/* Reusing all-players-list-container style */}
+                    <h2>All Registered Towns ({allTowns.length})</h2>
+                    {loadingAllTowns && <p>Loading all towns...</p>}
+                    {errorAllTowns && !loadingAllTowns && <p>Error: {errorAllTowns.message}</p>}
+
+                    {!loadingAllTowns && !errorAllTowns && allTowns.length > 0 && (
+                        <>
+                            <div className="data-display">
+                                {currentDisplayedTowns.map(town => (
+                                    <div key={town.uuid} className="all-players-item"> {/* Reusing all-players-item style */}
+                                        <div>
+                                            <p><strong>Name:</strong> {town.name}</p>
+                                            <p><strong>UUID:</strong> {town.uuid}</p>
+                                        </div>
+                                        <button onClick={() => openTownModalWithDetails(town.uuid)} className="button">
+                                            View Details
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                            {totalPages > 1 && (
+                                <div className="pagination-controls button-container pagination-controls-container">
+                                    <button onClick={prevPage} disabled={currentPage === 1} className="button">Previous</button>
+                                    <span className="pagination-page-info">Page {currentPage} of {totalPages}</span>
+                                    <button onClick={nextPage} disabled={currentPage === totalPages} className="button">Next</button>
+                                </div>
+                            )}
+                        </>
+                    )}
+                    {!loadingAllTowns && !errorAllTowns && allTowns.length === 0 && (
+                        <p>No towns found.</p>
+                    )}
+                </div>
+            )}
+
+            {loadingModalTown && <p className="modal-status-text">Loading town details...</p>}
+            {errorModalTown && <p className="modal-error-text">Error loading details: {errorModalTown.message}</p>}
+            <TownModal
+                isOpen={!!modalTown && !loadingModalTown && !errorModalTown}
+                town={modalTown}
+                onClose={closeModal}
+            />
+        </div>
+    );
+};
+
+export default Towns;

--- a/src/interfaces/town.ts
+++ b/src/interfaces/town.ts
@@ -77,6 +77,16 @@ export interface TownResident {
   uuid: string;
 }
 
+export interface TownQuarter {
+  name: string;
+  uuid: string;
+}
+
+export interface TownRank {
+  name: string;
+  uuid: string;
+}
+
 export interface TownDetailed extends TownBasic {
   board: string | null;
   founder: string;
@@ -85,12 +95,12 @@ export interface TownDetailed extends TownBasic {
   nation: TownNation;
   timestamps: TownTimestamps;
   status: TownStatus;
-  stats: TownStats;
+  stats: TownStats & { bonusBlocks: number };
   perms: TownPerms;
   coordinates: TownCoordinates;
   residents: TownResident[];
   trusted: TownResident[];
   outlaws: TownResident[];
-  quarters: string[];
-  ranks: Record<string, string[]>;
+  quarters: TownQuarter[];
+  ranks: Record<string, TownRank[]>;
 }

--- a/src/interfaces/town.ts
+++ b/src/interfaces/town.ts
@@ -1,0 +1,96 @@
+export interface TownBasic {
+  name: string;
+  uuid: string;
+}
+
+export interface TownMayor {
+  name: string;
+  uuid: string;
+}
+
+export interface TownNation {
+  name: string | null;
+  uuid: string | null;
+}
+
+export interface TownTimestamps {
+  registered: number;
+  joinedNationAt: number | null;
+  ruinedAt: number | null;
+}
+
+export interface TownStatus {
+  isPublic: boolean;
+  isOpen: boolean;
+  isNeutral: boolean;
+  isCapital: boolean;
+  isOverClaimed: boolean;
+  isRuined: boolean;
+  isForSale: boolean;
+  hasNation: boolean;
+  hasOverclaimShield: boolean;
+  canOutsidersSpawn: boolean;
+}
+
+export interface TownStats {
+  numTownBlocks: number;
+  maxTownBlocks: number;
+  numResidents: number;
+  numTrusted: number;
+  numOutlaws: number;
+  balance: number;
+  forSalePrice: number | null;
+}
+
+export interface TownPermsFlags {
+  pvp: boolean;
+  explosion: boolean;
+  fire: boolean;
+  mobs: boolean;
+}
+
+export interface TownPerms {
+  build: boolean[];
+  destroy: boolean[];
+  switch: boolean[];
+  itemUse: boolean[];
+  flags: TownPermsFlags;
+}
+
+export interface TownCoordinatesSpawn {
+  world: string;
+  x: number;
+  y: number;
+  z: number;
+  pitch: number;
+  yaw: number;
+}
+
+export interface TownCoordinates {
+  spawn: TownCoordinatesSpawn;
+  homeBlock: [number, number];
+  townBlocks: [number, number][];
+}
+
+export interface TownResident {
+  name: string;
+  uuid: string;
+}
+
+export interface TownDetailed extends TownBasic {
+  board: string | null;
+  founder: string;
+  wiki: string | null;
+  mayor: TownMayor;
+  nation: TownNation;
+  timestamps: TownTimestamps;
+  status: TownStatus;
+  stats: TownStats;
+  perms: TownPerms;
+  coordinates: TownCoordinates;
+  residents: TownResident[];
+  trusted: TownResident[];
+  outlaws: TownResident[];
+  quarters: string[];
+  ranks: Record<string, string[]>;
+}


### PR DESCRIPTION
This pull request introduces several significant changes to enhance functionality, improve navigation, and add new features to the EarthMC web application. The most notable updates include the implementation of single-page app (SPA) routing support for GitHub Pages, the addition of a detailed modal and search functionality for towns, and improvements to the navigation bar. Below is a categorized summary of the most important changes:

### SPA Routing Support
* Added a script in `index.html` to handle query string redirects for SPA routing on GitHub Pages. This ensures proper URL handling without triggering page reloads.
* Created a custom `404.html` file that redirects users to the correct SPA route by converting the path into a query string.

### Towns Feature Enhancements
* Implemented a new `TownModal` component to display detailed information about towns, including their stats, coordinates, residents, and permissions.
* Updated the `Towns` component to include search functionality, pagination, and a modal for viewing detailed town information.
* Added new TypeScript interfaces in `src/interfaces/town.ts` to define the structure of town-related data, including `TownBasic`, `TownDetailed`, and associated substructures.

### Navigation Improvements
* Modified the navigation bar to make the site title clickable, linking back to the homepage. Updated the "Home" menu item to "Status" for better clarity.
* Added styles to ensure navigation links in the header (`nav h1 a`) are white and have no text decoration.

### Minor Code Cleanup
* Removed an unnecessary comment in the `Players` component regarding API base URL determination.